### PR TITLE
Remove duplicate BucketForImagePolicy resource

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -48,23 +48,6 @@ Resources:
             Bool:
               aws:SecureTransport: false
 
-  # Enforce HTTPS only access to S3 bucket #
-  BucketForImagePolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref DestinationBucket
-      PolicyDocument:
-        Statement:
-        - Action: s3:*
-          Effect: Deny
-          Principal: "*"
-          Resource:
-          - !Sub "arn:aws:s3:::${DestinationBucket}/*"
-          - !Sub "arn:aws:s3:::${DestinationBucket}"
-          Condition:
-            Bool:
-              aws:SecureTransport: false
-
   ## SQS Queue
   S3EventQueue:
     Type: "AWS::SQS::Queue"


### PR DESCRIPTION
The BucketForImagePolicy resource is included twice in the template. This creates an error in Application Composer when the template is loaded.

*Description of changes:*

Fixing the following error in App Composer:
![Screenshot 2023-12-14 at 10 19 46 AM](https://github.com/aws-samples/serverless-face-blur-service/assets/5382821/15209234-148e-4438-910c-389d93723502)
![Screenshot 2023-12-14 at 10 20 00 AM](https://github.com/aws-samples/serverless-face-blur-service/assets/5382821/d8623300-c7fb-4dbc-891a-6d4f46b50d1b)

