### PR TITLE
Fix duplicate BucketForImagePolicy resource names

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -32,7 +32,7 @@ Resources:
       BucketName: !Ref DestinationBucketName
 
   # Enforce HTTPS only access to S3 bucket #
-  BucketForImagePolicy:
+  SourceBucketForImagePolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
       Bucket: !Ref SourceBucket
@@ -49,7 +49,7 @@ Resources:
               aws:SecureTransport: false
 
   # Enforce HTTPS only access to S3 bucket #
-  BucketForImagePolicy:
+  DestinationBucketForImagePolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
       Bucket: !Ref DestinationBucket


### PR DESCRIPTION
The BucketForImagePolicy resource is included twice in the template. This creates an error in Application Composer when the template is loaded.

*Issue #, if available:*

*Description of changes:*

Fixing the following error in App Composer:
![Screenshot 2023-12-14 at 10 19 46 AM](https://github.com/aws-samples/serverless-face-blur-service/assets/5382821/7ae62c90-0e2f-4876-8c0d-da48ee7c0dca)
![Screenshot 2023-12-14 at 10 20 00 AM](https://github.com/aws-samples/serverless-face-blur-service/assets/5382821/c14cb8d0-41e3-4390-810e-e402481a7044)

![Screenshot 2023-12-14 at 10 27 39 AM](https://github.com/aws-samples/serverless-face-blur-service/assets/5382821/03b164dc-5912-43a6-9cc8-7695793dd0d6)
